### PR TITLE
CURL file upload PHP 5.6 compatibility

### DIFF
--- a/classes/Upload.php
+++ b/classes/Upload.php
@@ -40,7 +40,7 @@ class Upload
     function file($filep, $options = array())
     {
         $uri = $this->endpoint . "/upload";
-        $options['image'] = '@'.$filep;
+        $options['image'] = (function_exists('curl_file_create')) ? curl_file_create($filep) : '@'.$filep;
         return $this->conn->request($uri, $options, "POST");
     }
 


### PR DESCRIPTION
In PHP 5.6 @ option is switched off by default:
https://wiki.php.net/rfc/curl-file-upload#backward_compatibility
http://www.58bits.com/blog/2014/06/14/how-upload-file-using-php-curl